### PR TITLE
respond differently according to file mime type

### DIFF
--- a/routes/routes.php
+++ b/routes/routes.php
@@ -5,7 +5,8 @@ use Illuminate\Support\Facades\Storage;
 
 foreach (config('local-temporary-url.disk') as $disk) {
     Route::get("$disk/temp/{path}", function (string $path) use ($disk) {
-        return Storage::disk($disk)->download($path);
+        $file = Storage::disk($disk)->get($path);
+        return response($file, 200, ['Content-Type' => Storage::mimeType($path)]);
     })
         ->where('path', '.*')
         ->middleware(config('local-temporary-url.middleware'))


### PR DESCRIPTION
mime types matter and should change the behavior of the temp link. For example, if it's an image, you want to display it in the browser and not download it.